### PR TITLE
QE: Update Uyuni container for PR tests to 2025.07

### DIFF
--- a/.github/workflows/acceptance_tests_base.yml
+++ b/.github/workflows/acceptance_tests_base.yml
@@ -19,7 +19,7 @@ on:
         type: string
 
 env:
-  UYUNI_PROJECT: uyuni-project
+  UYUNI_PROJECT: nodeg
   UYUNI_VERSION: master
   NO_AUTH_REGISTRY: "noauthregistry.lab"
   PUBLISH_CUCUMBER_REPORT: true

--- a/.github/workflows/acceptance_tests_coordinator.yml
+++ b/.github/workflows/acceptance_tests_coordinator.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  UYUNI_PROJECT: uyuni-project
+  UYUNI_PROJECT: nodeg
   UYUNI_VERSION: master
 
 jobs:


### PR DESCRIPTION
This will bump the version of the Uyuni PR tests to the newly released
version 2025.07.## What does this PR change?
